### PR TITLE
Update function names; remove a deprecated log call

### DIFF
--- a/bury_ahead.py
+++ b/bury_ahead.py
@@ -90,11 +90,11 @@ def buryNewSibsMenu():
 	mw.col.save()
 	today = int((time.time() - mw.col.crt) // 86400)
 	cutoff = today+ahead
-	dids = mw.col.decks.allIds()
+	dids = mw.col.decks.all_ids()
 	didsRevuBury = [0]
 	didsNewBury = [0]
 	for did in dids:
-		conf = mw.col.decks.confForDid(did)
+		conf = mw.col.decks.config_dict_for_deck_id(did)
 		if not conf["dyn"]:
 			if conf["rev"]["bury"]:
 				didsRevuBury.append(did)
@@ -124,7 +124,6 @@ def buryNewSibsMenu():
 			mw.col.db.execute(
 				"update cards set queue=-2,mod=?,usn=? where id in "+ids2str(cidsToBury),
 				intTime(), mw.col.usn())
-			mw.col.log(cidsToBury)
 	tooltip("Siblings buried prospectively, out "+str(ahead)+" days")
 
 


### PR DESCRIPTION
This updates old function names (`mw.col.decks.allIds()` and `mw.col.decks.confForDid()`) to new ones and removes a call to a deprecated log function (`mw.col.log()`).

The reason for this change is not only keeping up with changes in Anki and ensuring future compatibility but also because the previous state introduced a problem that rendered the add-on unusable under a specific situation with Anki 2.1.45 (https://github.com/rjgoif/anki-bury-future-sibs/issues/4).

Not that `all_ids()` is still deprecated (but not as deprecated as `allIds()` 😉), as this warning appears in the shell when I use add-on (everything works fine, though):

    addons21/930365039/bury_ahead.py:94:all_ids() is deprecated: please use all_names_and_ids instead.

I’m sure getting only the `id`s from `all_names_and_ids()` is easy, but I don’t have the time to change and test it right now. For now `all_ids()` works fine.
