### PR TITLE
23.10 support

### DIFF
--- a/bury_ahead.py
+++ b/bury_ahead.py
@@ -49,7 +49,7 @@ import anki
 import aqt
 import aqt.preferences
 import aqt.deckconf
-import anki.sched
+from anki.scheduler import v3
 import time
 from aqt.utils import showInfo, tooltip
 from anki.utils import ids2str, intTime, fmtTimeSpan

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "ahead": 21,
   "newsAlwaysFirst": false,
-  "shortcut": "Shift+B"
+  "shortcut": "Shift+B",
   "onStartup": false
 }


### PR DESCRIPTION
This solves #7. Note that #8 has also to be patched, as it updates the add-on to add support to version 2.1.45 (now an ancient history…).

The `config.json` file was malformed, and the old v2 scheduler was used. These two are fixed by this pull request.

I see there is no activity on this repo. I would like to avoid this, but if the add-on is not updated to accomodate changes in Anki I will have no alternative but to fork it.

Thanks for this much needed add-on! IMHO this should be a built-in core functionality of Anki.